### PR TITLE
Fix security vulnerabilities in dependencies

### DIFF
--- a/django_certiffy_project/requirements.txt
+++ b/django_certiffy_project/requirements.txt
@@ -5,7 +5,7 @@ cffi==1.15.1
 charset-normalizer==3.2.0
 click==8.1.7
 crispy-bootstrap5==2023.10
-cryptography
+cryptography==42.0.8
 Django==4.2.28
 django-crispy-forms==2.1
 django-crontab==0.7.1

--- a/django_certiffy_project/requirements.txt
+++ b/django_certiffy_project/requirements.txt
@@ -1,5 +1,5 @@
 asgiref==3.7.2
-black==24.3.0
+black==24.4.2
 certifi==2024.7.4
 cffi==1.15.1
 charset-normalizer==3.2.0


### PR DESCRIPTION
## Summary
- Upgrade Django 4.2.4 → 4.2.28 (multiple CVEs)
- Upgrade gunicorn 21.2.0 → 22.0.0 (CVE-2024-1135, HTTP Request Smuggling)
- Upgrade requests 2.31.0 → 2.32.4 (CVE-2023-32681, proxy credential leak)
- Upgrade sqlparse 0.4.4 → 0.5.0 (CVE-2024-4340, ReDoS)
- Upgrade black 23.7.0 → 24.4.2 (CVE-2024-21503, ReDoS)
- Pin cryptography to 42.0.8 (CVE-2024-26130, NULL pointer dereference)
- Upgrade urllib3, certifi, idna, dnspython to patched versions

## Test plan
- [ ] Verify application starts successfully after dependency upgrades
- [ ] Run existing test suite

🤖 Generated with [Claude Code](https://claude.com/claude-code)